### PR TITLE
Update fix for API Fetch CORS Error constants.js

### DIFF
--- a/js/components/constants.js
+++ b/js/components/constants.js
@@ -1,2 +1,2 @@
-export const apiUrl = "https://a33.no/wp-json/wc/store/products";
+export const apiUrl = "https://cors.noroff.dev/a33.no/wp-json/wc/store/products";
 export const spinnerDiv = `<div class="lds-dual-ring"></div>`;


### PR DESCRIPTION
Between 4/9 and 5/9 Night time Wordpress blocked my site because of a critical error with a plugin that were ment to fix CORS error. Enable CORSE had an update around the same time that might be why this happened. A few hour later I saw this and deactivated the plugin so my site was back. But Now CORS error appears. After giving notice to Oliver I found that this fix worked so I can fetch API again and everything works as it should by adding https://cors.noroff.dev/ infront of my api. So as instructed I have put in this Pull request with the changes. 